### PR TITLE
test: add automated skill evaluation campaign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,8 @@ __marimo__/
 .streamlit/secrets.toml
 
 .agents/changes/
+
+# Skill evaluation outputs (generated, not committed)
+skills-evals/iteration-*/
+skills-evals/results/
+skills-evals/eval-report.html

--- a/README.md
+++ b/README.md
@@ -247,6 +247,32 @@ for finding in report.findings:
 
 Documentation is available at [okf-schema/README.md](https://github.com/gsemet/okf-schema/blob/main/README.md).
 
+## Evaluation
+
+`okf-schema` includes an automated skill evaluation campaign in `skills-evals/` that validates the tool against a suite of fixture bundles. These evals verify that the validator correctly identifies conformant bundles, catches structural errors (E1–E6), reports warnings (W1–W7), and handles JSONSchema validation with both JSON and YAML schema databases.
+
+| Eval | Description |
+|------|-------------|
+| `validate-conformant-bundle` | Validates a fully conformant OKF bundle (0 errors, 0 warnings) |
+| `validate-non-conformant-bundle` | Validates a bundle with known errors (E1–E3) and warnings (W1–W7) |
+| `create-okf-bundle` | Creates a new OKF bundle from scratch and validates it |
+| `validate-with-schema-database` | Tests JSONSchema validation with `--schema-db` |
+| `validate-with-yaml-schema-database` | Tests YAML schema file support in schema DB |
+
+Run the eval campaign:
+```bash
+# Trigger eval via Copilot-CLI
+just copilot-cli-eval-okf-schema
+
+# Score eval outputs and generate report
+just eval-okf-schema
+
+# Open eval review in browser
+just eval-view-okf-schema
+```
+
+The eval system supports A/B comparison (`with_skill` vs `without_skill`) across iteration directories. Results are rendered as an interactive HTML dashboard.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/gsemet/okf-schema/blob/main/CONTRIBUTING.md) for development setup and guidelines.

--- a/justfile
+++ b/justfile
@@ -87,3 +87,22 @@ refresh-examples:
     {{ uv_run }} okf-schema validate --path examples/ai-llm-knowledge-base --strict
     {{ uv_run }} okf-schema stats --path examples/ai-llm-knowledge-base
     {{ uv_run }} okf-schema list --path examples/ai-llm-knowledge-base
+
+# ── Skill Evals ──────────────────────────────────────────────────────────────
+
+# Trigger okf-schema skill eval via Copilot-CLI
+[group('eval')]
+copilot-cli-eval-okf-schema:
+    # Or in Copilot chat: "Please follow the instructions in skills-evals/eval.prompt.md"
+    copilot --prompt skills-evals/eval.prompt.md
+
+# Score okf-schema eval outputs and generate report
+[group('eval')]
+eval-okf-schema:
+    bash skills-evals/eval-runner.sh
+    bash skills-evals/eval-viewer.sh
+
+# Open okf-schema eval review in browser
+[group('eval')]
+eval-view-okf-schema:
+    bash skills-evals/eval-viewer.sh

--- a/skills-evals/eval-runner.sh
+++ b/skills-evals/eval-runner.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# eval-runner.sh — Pre-flight checks and scoring for OKF skill evaluation campaign
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+EVAL_DIR="$PROJECT_DIR/skills-evals"
+RESULTS_DIR="$EVAL_DIR/results"
+
+mkdir -p "$RESULTS_DIR"
+
+echo "=== OKF Schema Skill Eval Runner ==="
+echo "Project dir: $PROJECT_DIR"
+echo "Results dir: $RESULTS_DIR"
+echo ""
+
+# Verify dependencies
+echo "Checking okf-schema..."
+if ! uv run -- okf-schema --version >/dev/null 2>&1; then
+    echo "ERROR: okf-schema not found. Run 'uv sync' to install dependencies."
+    exit 1
+fi
+
+# Verify fixtures
+echo "Checking fixtures..."
+for fixture in conformant-bundle non-conformant schema-valid-bundle schema-invalid-bundle schema-db schema-db-yaml; do
+    if [ ! -d "$EVAL_DIR/fixtures/$fixture" ]; then
+        echo "ERROR: Missing fixture: $fixture"
+        exit 1
+    fi
+done
+
+echo "All checks passed."
+echo ""
+
+# Check for iteration directories
+LATEST_ITERATION=$(find "$EVAL_DIR" -maxdepth 1 -type d -name 'iteration-*' | sort -V | tail -n 1)
+
+if [ -n "$LATEST_ITERATION" ]; then
+    ITERATION_NAME=$(basename "$LATEST_ITERATION")
+    echo "Found iteration: $ITERATION_NAME"
+    echo "  Location: $LATEST_ITERATION"
+    echo ""
+    echo "Eval cases found:"
+    for eval_dir in "$LATEST_ITERATION"/*/; do
+        if [ -d "$eval_dir" ]; then
+            name=$(basename "$eval_dir")
+            has_with_skill=$([ -d "$eval_dir/with_skill" ] && echo "✅" || echo "❌")
+            has_without_skill=$([ -d "$eval_dir/without_skill" ] && echo "✅" || echo "❌")
+            echo "  - $name  with_skill:$has_with_skill  without_skill:$has_without_skill"
+        fi
+    done
+    echo ""
+    echo "To view the report, run: just eval-view-okf-schema"
+else
+    echo "No iteration directories found yet."
+    echo ""
+    echo "To trigger the eval campaign:"
+    echo "  1. Run: just copilot-cli-eval-okf-schema"
+    echo "  2. Or open this prompt in Copilot: skills-evals/eval.prompt.md"
+fi

--- a/skills-evals/eval-viewer.py
+++ b/skills-evals/eval-viewer.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""A/B Comparison viewer for okf-schema skill evals.
+
+Generates a standalone HTML report comparing "with_skill" vs "without_skill"
+results from iteration directories.
+
+Usage:
+    python eval-viewer.py              # Auto-detect iteration-*/ dirs
+    python eval-viewer.py --serve      # Serve on localhost
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import webbrowser
+
+
+def load_grading(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        # Normalize
+        if "summary" not in data:
+            def _is_passed(a: dict) -> bool:
+                if "passed" in a:
+                    return bool(a["passed"])
+                if "pass" in a:
+                    return bool(a["pass"])
+                if "result" in a:
+                    return a["result"].upper() == "PASS"
+                return False
+
+            passed = sum(1 for a in data.get("assertions", []) if _is_passed(a))
+            total = len(data.get("assertions", []))
+            data = {
+                "summary": {
+                    "pass_rate": passed / total if total else 0.0,
+                    "passed": passed,
+                    "failed": total - passed,
+                    "total": total,
+                },
+                "expectations": [
+                    {
+                        "text": a.get("assertion", a.get("id", a.get("text", ""))),
+                        "passed": _is_passed(a),
+                        "evidence": a.get("evidence", a.get("justification", "")),
+                    }
+                    for a in data.get("assertions", [])
+                ],
+            }
+        return data
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def build_comparison(iteration_dir: Path) -> list[dict]:
+    comparisons = []
+    for eval_dir in sorted(iteration_dir.iterdir()):
+        if not eval_dir.is_dir() or eval_dir.name.startswith("."):
+            continue
+        with_skill = load_grading(eval_dir / "with_skill" / "grading.json")
+        without_skill = load_grading(eval_dir / "without_skill" / "grading.json")
+        if with_skill or without_skill:
+            comparisons.append({
+                "name": eval_dir.name,
+                "with_skill": with_skill,
+                "without_skill": without_skill,
+            })
+    return comparisons
+
+
+def generate_html(comparisons: list[dict], iteration_name: str) -> str:
+    rows = []
+    for comp in comparisons:
+        name = comp["name"]
+        ws = comp["with_skill"]
+        wos = comp["without_skill"]
+
+        ws_rate = ws["summary"]["pass_rate"] * 100 if ws else 0
+        wos_rate = wos["summary"]["pass_rate"] * 100 if wos else 0
+        delta = ws_rate - wos_rate
+        delta_class = "positive" if delta > 0 else ("negative" if delta < 0 else "neutral")
+
+        # Build expectation comparison table
+        exp_rows = []
+        all_texts = set()
+        if ws:
+            all_texts.update(e["text"] for e in ws.get("expectations", []))
+        if wos:
+            all_texts.update(e["text"] for e in wos.get("expectations", []))
+
+        for text in sorted(all_texts):
+            ws_exp = next((e for e in ws.get("expectations", []) if e["text"] == text), None) if ws else None
+            wos_exp = next((e for e in wos.get("expectations", []) if e["text"] == text), None) if wos else None
+
+            ws_pass = ws_exp["passed"] if ws_exp else None
+            wos_pass = wos_exp["passed"] if wos_exp else None
+
+            if ws_pass is True and wos_pass is False:
+                row_class = "improved"
+                indicator = "▲ Improved"
+            elif ws_pass is False and wos_pass is True:
+                row_class = "regressed"
+                indicator = "▼ Regressed"
+            elif ws_pass == wos_pass and ws_pass is not None:
+                row_class = "same"
+                indicator = "● Same"
+            else:
+                row_class = "new"
+                indicator = "◆ New"
+
+            exp_rows.append(f"""
+                <tr class="{row_class}">
+                    <td class="exp-text">{text}</td>
+                    <td class="pass-cell {'pass' if ws_pass else ('fail' if ws_pass is False else 'na')}">{"✅ PASS" if ws_pass else ("❌ FAIL" if ws_pass is False else "—")}</td>
+                    <td class="pass-cell {'pass' if wos_pass else ('fail' if wos_pass is False else 'na')}">{"✅ PASS" if wos_pass else ("❌ FAIL" if wos_pass is False else "—")}</td>
+                    <td class="indicator">{indicator}</td>
+                </tr>
+            """)
+
+        rows.append(f"""
+        <div class="eval-card">
+            <div class="eval-header">
+                <h3>{name}</h3>
+                <div class="scores">
+                    <div class="score-box with-skill">
+                        <span class="score-label">With Skill</span>
+                        <span class="score-value">{ws_rate:.0f}%</span>
+                        <span class="score-detail">{ws["summary"]["passed"] if ws else 0}/{ws["summary"]["total"] if ws else 0}</span>
+                    </div>
+                    <div class="score-box without-skill">
+                        <span class="score-label">Without Skill</span>
+                        <span class="score-value">{wos_rate:.0f}%</span>
+                        <span class="score-detail">{wos["summary"]["passed"] if wos else 0}/{wos["summary"]["total"] if wos else 0}</span>
+                    </div>
+                    <div class="score-box delta {delta_class}">
+                        <span class="score-label">Delta</span>
+                        <span class="score-value">{'+' if delta > 0 else ''}{delta:.0f}%</span>
+                    </div>
+                </div>
+            </div>
+            <table class="comparison-table">
+                <thead>
+                    <tr>
+                        <th>Expectation</th>
+                        <th>With Skill</th>
+                        <th>Without Skill</th>
+                        <th>Change</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {''.join(exp_rows)}
+                </tbody>
+            </table>
+        </div>
+        """)
+
+    # Summary stats
+    total_delta = sum(
+        (comp["with_skill"]["summary"]["pass_rate"] * 100 if comp["with_skill"] else 0) -
+        (comp["without_skill"]["summary"]["pass_rate"] * 100 if comp["without_skill"] else 0)
+        for comp in comparisons
+    )
+    avg_delta = total_delta / len(comparisons) if comparisons else 0
+    improved = sum(1 for c in comparisons if c["with_skill"] and c["without_skill"] and c["with_skill"]["summary"]["pass_rate"] > c["without_skill"]["summary"]["pass_rate"])
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OKF Schema Skill Eval — A/B Comparison</title>
+    <style>
+        :root {{
+            --bg: #0d1117;
+            --surface: #161b22;
+            --border: #30363d;
+            --text: #c9d1d9;
+            --text-secondary: #8b949e;
+            --accent: #58a6ff;
+            --pass: #3fb950;
+            --fail: #f85149;
+            --improved: #2ea043;
+            --regressed: #da3633;
+            --neutral: #8b949e;
+        }}
+        * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.6;
+            padding: 2rem;
+        }}
+        .container {{ max-width: 1200px; margin: 0 auto; }}
+        header {{ text-align: center; margin-bottom: 2rem; }}
+        h1 {{ font-size: 2rem; margin-bottom: 0.5rem; }}
+        .subtitle {{ color: var(--text-secondary); }}
+        .summary-bar {{
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+            margin-bottom: 2rem;
+            flex-wrap: wrap;
+        }}
+        .summary-pill {{
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem 1.5rem;
+            text-align: center;
+            min-width: 140px;
+        }}
+        .summary-pill .value {{ font-size: 1.5rem; font-weight: bold; color: var(--accent); }}
+        .summary-pill .label {{ font-size: 0.85rem; color: var(--text-secondary); }}
+        .eval-card {{
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            margin-bottom: 1.5rem;
+            overflow: hidden;
+        }}
+        .eval-header {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border);
+            flex-wrap: wrap;
+            gap: 1rem;
+        }}
+        .eval-header h3 {{ font-size: 1.1rem; }}
+        .scores {{ display: flex; gap: 1rem; }}
+        .score-box {{
+            text-align: center;
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            background: var(--bg);
+            min-width: 100px;
+        }}
+        .score-label {{ display: block; font-size: 0.7rem; color: var(--text-secondary); text-transform: uppercase; }}
+        .score-value {{ display: block; font-size: 1.3rem; font-weight: bold; }}
+        .score-detail {{ display: block; font-size: 0.75rem; color: var(--text-secondary); }}
+        .delta.positive {{ color: var(--pass); }}
+        .delta.negative {{ color: var(--fail); }}
+        .comparison-table {{ width: 100%; border-collapse: collapse; }}
+        .comparison-table th {{
+            text-align: left;
+            padding: 0.75rem 1.5rem;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            color: var(--text-secondary);
+            border-bottom: 1px solid var(--border);
+        }}
+        .comparison-table td {{
+            padding: 0.75rem 1.5rem;
+            border-bottom: 1px solid var(--border);
+            font-size: 0.9rem;
+        }}
+        .comparison-table tr:last-child td {{ border-bottom: none; }}
+        .exp-text {{ max-width: 500px; }}
+        .pass-cell.pass {{ color: var(--pass); font-weight: 600; }}
+        .pass-cell.fail {{ color: var(--fail); font-weight: 600; }}
+        .pass-cell.na {{ color: var(--text-secondary); }}
+        tr.improved {{ background: rgba(46, 160, 67, 0.1); }}
+        tr.regressed {{ background: rgba(218, 54, 51, 0.1); }}
+        tr.same {{ }}
+        tr.new {{ background: rgba(88, 166, 255, 0.05); }}
+        .indicator {{ font-size: 0.8rem; font-weight: 600; }}
+        tr.improved .indicator {{ color: var(--improved); }}
+        tr.regressed .indicator {{ color: var(--regressed); }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🔍 OKF Schema Skill Eval</h1>
+            <p class="subtitle">A/B Comparison: With Skill vs Without Skill — {iteration_name}</p>
+        </header>
+        <div class="summary-bar">
+            <div class="summary-pill">
+                <div class="value">{len(comparisons)}</div>
+                <div class="label">Evaluations</div>
+            </div>
+            <div class="summary-pill">
+                <div class="value">{'+' if avg_delta > 0 else ''}{avg_delta:.0f}%</div>
+                <div class="label">Avg Improvement</div>
+            </div>
+            <div class="summary-pill">
+                <div class="value">{improved}/{len(comparisons)}</div>
+                <div class="label">Improved</div>
+            </div>
+        </div>
+        {''.join(rows)}
+    </div>
+</body>
+</html>"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="OKF Schema Skill Eval A/B Viewer")
+    parser.add_argument("--iteration", "-i", type=Path, default=Path("iteration-1"))
+    parser.add_argument("--output", "-o", type=Path, default=Path("eval-report.html"))
+    parser.add_argument("--serve", "-s", action="store_true", help="Serve on localhost")
+    parser.add_argument("--port", "-p", type=int, default=8117)
+    args = parser.parse_args()
+
+    iteration_dir = args.iteration
+    if not iteration_dir.exists():
+        print(f"Error: {iteration_dir} not found", file=sys.stderr)
+        sys.exit(1)
+
+    comparisons = build_comparison(iteration_dir)
+    if not comparisons:
+        print("No eval comparisons found", file=sys.stderr)
+        sys.exit(1)
+
+    html = generate_html(comparisons, iteration_dir.name)
+    args.output.write_text(html)
+    print(f"Report written to: {args.output.resolve()}")
+
+    if args.serve:
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path in ("/", "/index.html"):
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html")
+                    self.end_headers()
+                    self.wfile.write(html.encode())
+                else:
+                    self.send_error(404)
+            def log_message(self, *a): pass
+
+        server = HTTPServer(("127.0.0.1", args.port), Handler)
+        url = f"http://localhost:{args.port}"
+        print(f"Serving at {url}")
+        webbrowser.open(url)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills-evals/eval-viewer.sh
+++ b/skills-evals/eval-viewer.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# eval-viewer.sh — Generate and open an HTML eval report for okf-schema
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find the latest iteration directory
+LATEST_ITERATION=$(find "$SCRIPT_DIR" -maxdepth 1 -type d -name 'iteration-*' | sort -V | tail -n 1)
+
+if [ -z "$LATEST_ITERATION" ]; then
+    echo "❌ No iteration directories found. Run the eval campaign first."
+    echo "   Expected: skills-evals/iteration-1/"
+    exit 1
+fi
+
+ITERATION_NAME=$(basename "$LATEST_ITERATION")
+OUTPUT_FILE="$SCRIPT_DIR/eval-report.html"
+
+echo "=== OKF Schema Eval Viewer ==="
+echo "Iteration: $ITERATION_NAME"
+echo "Output:    $OUTPUT_FILE"
+echo ""
+
+# Generate the report
+python3 "$SCRIPT_DIR/eval-viewer.py" \
+    --iteration "$LATEST_ITERATION" \
+    --output "$OUTPUT_FILE"
+
+echo ""
+echo "✅ Report generated: $OUTPUT_FILE"
+
+# Open in browser (macOS)
+if command -v open >/dev/null 2>&1; then
+    open "$OUTPUT_FILE"
+    echo "🌐 Opened in browser"
+fi

--- a/skills-evals/eval.prompt.md
+++ b/skills-evals/eval.prompt.md
@@ -1,0 +1,69 @@
+---
+agent: agent
+description: 'Trigger the okf-schema skill evaluation campaign. Runs all evals in skills-evals/evals.json against the skill.'
+model: gpt-5.4
+name: okf-schema-eval-trigger
+---
+
+# OKF Schema Skill Evaluation Trigger
+
+You are running the evaluation campaign for the **okf-schema** skill (Open Knowledge Format bundle validation and management).
+
+## Setup
+
+1. Read `skills-evals/evals.json` to discover all eval cases.
+2. Ensure the project root is at the okf-schema repository root.
+3. Verify `okf-schema` is available via `uv run -- okf-schema --version`.
+
+## Pre-flight
+
+- Confirm `okf-schema` is available (`uv sync` if needed).
+- Confirm the fixture directories exist under `skills-evals/`:
+  - `skills-evals/fixtures/conformant-bundle/`
+  - `skills-evals/fixtures/non-conformant/`
+  - `skills-evals/fixtures/schema-valid-bundle/`
+  - `skills-evals/fixtures/schema-invalid-bundle/`
+  - `skills-evals/fixtures/schema-db/`
+  - `skills-evals/fixtures/schema-db-yaml/`
+
+## Execution
+
+For each eval case in `skills-evals/evals.json`:
+
+1. Spawn a **fresh subagent** (use the default agent) with the eval's `prompt`.
+2. Provide the subagent with:
+   - The skill's `SKILL.md` (`skills/okf-schema/SKILL.md`)
+   - The `okf-schema` CLI reference (`uv run -- okf-schema --help`)
+   - Any fixture paths listed in the eval's `files` array
+3. The subagent must execute the task and return its full transcript + any generated files.
+4. Capture the subagent output into `skills-evals/results/<eval_name>/transcript.md`.
+5. Grade the result by checking each assertion in the eval case:
+   - For each assertion, mark PASS or FAIL with a one-line justification.
+   - Save the grading report to `skills-evals/results/<eval_name>/grading.json`.
+
+## Grading Format (`grading.json`)
+
+```json
+{
+  "eval_id": 1,
+  "eval_name": "validate-conformant-bundle",
+  "overall": "PASS",
+  "assertions": [
+    {
+      "assertion": "The agent executed okf-schema validate...",
+      "result": "PASS",
+      "justification": "Transcript shows okf-schema validate --path ..."
+    }
+  ],
+  "notes": "Any additional observations"
+}
+```
+
+## Completion
+
+After all evals are graded:
+
+1. Summarize results in `skills-evals/results/summary.md`:
+   - Total evals, passed, failed
+   - Per-eval verdict with link to grading.json
+2. Report the final summary to the user.

--- a/skills-evals/evals.json
+++ b/skills-evals/evals.json
@@ -1,0 +1,81 @@
+{
+  "skill_name": "okf-schema",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "validate-conformant-bundle",
+      "prompt": "THIS IS AN AUTOMATED EVAL — SKIP ANY INTERVIEW AND PROCEED DIRECTLY TO VALIDATION.\n\nValidate the OKF bundle at skills-evals/fixtures/conformant-bundle/ using okf-schema. Run:\n  uv run -- okf-schema validate --path skills-evals/fixtures/conformant-bundle/\nReport the results. Confirm the bundle passes all conformance rules with no errors.",
+      "expected_output": "Validator reports the bundle is fully conformant with OKF v0.1 — no errors, no warnings.",
+      "files": ["skills-evals/fixtures/conformant-bundle/"],
+      "assertions": [
+        "The agent executed okf-schema validate on the conformant bundle",
+        "The validator output contains 'Bundle is conformant' or 'conformant'",
+        "The validator reports zero errors (no E1, E2, or E3 findings)",
+        "The validator reports zero warnings (no W1–W7 findings)"
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "validate-non-conformant-bundle",
+      "prompt": "THIS IS AN AUTOMATED EVAL — SKIP ANY INTERVIEW AND PROCEED DIRECTLY TO VALIDATION.\n\nValidate the OKF bundle at skills-evals/fixtures/non-conformant/ using okf-schema. Run:\n  uv run -- okf-schema validate --path skills-evals/fixtures/non-conformant/\nReport the results. Identify every conformance error (E1–E3) and warning (W1–W7) found.",
+      "expected_output": "Validator reports specific errors: E1 (missing frontmatter), E2 (missing type), E3 (unexpected frontmatter in subdir index.md). Warnings: W1 (missing title/description), W2 (broken link), W3 (missing timestamp), W5 (bad log date format).",
+      "files": ["skills-evals/fixtures/non-conformant/"],
+      "assertions": [
+        "The agent executed okf-schema validate on the non-conformant bundle",
+        "The validator output reports at least one E1 error (missing frontmatter)",
+        "The validator output reports at least one E2 error (missing type field)",
+        "The validator output reports at least one E3 error (unexpected frontmatter in reserved file)",
+        "The validator output reports at least one W2 warning (broken cross-link)",
+        "The validator output reports at least one W5 warning (log.md date not ISO 8601)",
+        "The final verdict states the bundle is NOT conformant"
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "create-okf-bundle",
+      "prompt": "THIS IS AN AUTOMATED EVAL — SKIP ANY INTERVIEW AND PROCEED DIRECTLY TO CREATION.\n\nCreate a new OKF bundle for a SaaS analytics domain with the following concepts: a 'users' table, a 'subscriptions' table, and an 'mrr' (Monthly Recurring Revenue) metric. Save the bundle under skills-evals/fixtures/create-output/. Follow all OKF rules: YAML frontmatter with type field, cross-links between concepts, index.md files for progressive disclosure, and bundle-root index.md with okf_version. Then run okf-schema validate on the created bundle to confirm conformance.",
+      "expected_output": "A complete OKF bundle with 3 concepts (users table, subscriptions table, mrr metric), proper frontmatter, cross-links, index.md files, and a passing validator result.",
+      "files": [],
+      "assertions": [
+        "The agent created an OKF bundle directory at skills-evals/fixtures/create-output/",
+        "The bundle contains at least 3 concept .md files with YAML frontmatter",
+        "Every concept file has a non-empty 'type' field in its frontmatter",
+        "The bundle contains at least one index.md file for progressive disclosure",
+        "The bundle-root index.md declares okf_version: \"0.1\" in its frontmatter",
+        "Concept files contain cross-links to each other using markdown link syntax",
+        "The agent ran okf-schema validate on the created bundle",
+        "The validator reports the created bundle is conformant (no errors)"
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "validate-with-schema-database",
+      "prompt": "THIS IS AN AUTOMATED EVAL — SKIP ANY INTERVIEW AND PROCEED DIRECTLY TO VALIDATION.\n\nTest the OKF validator's schema validation feature using okf-schema.\n\n1. Run okf-schema validate with --schema-db on the conformant schema-valid bundle:\n   uv run -- okf-schema validate --path skills-evals/fixtures/schema-valid-bundle/ --schema-db skills-evals/fixtures/schema-db/\n   Confirm it passes with no errors and no warnings.\n\n2. Run okf-schema validate with --schema-db on the non-conformant schema-invalid bundle:\n   uv run -- okf-schema validate --path skills-evals/fixtures/schema-invalid-bundle/ --schema-db skills-evals/fixtures/schema-db/\n   Confirm it reports E4 errors for schema violations (extra field in table, invalid enum value in metric) and a W6 warning for the unknown type 'dashboard'. Confirm the bundle is NOT conformant.",
+      "expected_output": "Schema-valid bundle passes with zero errors and zero warnings. Schema-invalid bundle reports E4 errors for schema violations (extra field, invalid enum) and W6 warning for missing schema. Both results correctly identify conformance status.",
+      "files": ["skills-evals/fixtures/schema-valid-bundle/", "skills-evals/fixtures/schema-invalid-bundle/", "skills-evals/fixtures/schema-db/"],
+      "assertions": [
+        "The agent executed okf-schema validate with --schema-db on schema-valid-bundle",
+        "The validator output for schema-valid-bundle reports zero errors (no E1–E4)",
+        "The validator output for schema-valid-bundle reports zero warnings (no W1–W7)",
+        "The agent executed okf-schema validate with --schema-db on schema-invalid-bundle",
+        "The validator output for schema-invalid-bundle reports at least one E4 error (schema validation failure)",
+        "The validator output for schema-invalid-bundle reports at least one W6 warning (no schema found for type)",
+        "The validator output for schema-invalid-bundle states the bundle is NOT conformant",
+        "The validator output for schema-valid-bundle states the bundle is conformant"
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "validate-with-yaml-schema-database",
+      "prompt": "THIS IS AN AUTOMATED EVAL — SKIP ANY INTERVIEW AND PROCEED DIRECTLY TO VALIDATION.\n\nTest that the OKF validator supports YAML schema files in the schema database.\n\n1. Run okf-schema validate with --schema-db pointing to the YAML-only schema database:\n   uv run -- okf-schema validate --path skills-evals/fixtures/schema-valid-bundle/ --schema-db skills-evals/fixtures/schema-db-yaml/\n   Confirm it passes with no errors and no warnings.\n\n2. Confirm that the YAML schemas are functionally equivalent to the JSON versions by comparing the validation results.",
+      "expected_output": "Schema-valid bundle passes with zero errors and zero warnings using YAML schemas. Schema linter reports all YAML schemas as valid. Results match JSON schema validation.",
+      "files": ["skills-evals/fixtures/schema-valid-bundle/", "skills-evals/fixtures/schema-db-yaml/"],
+      "assertions": [
+        "The agent executed okf-schema validate with --schema-db on schema-db-yaml",
+        "The validator output for schema-valid-bundle reports zero errors (no E1–E4)",
+        "The validator output for schema-valid-bundle reports zero warnings (no W1–W7)",
+        "The validator output for schema-valid-bundle states the bundle is conformant"
+      ]
+    }
+  ]
+}

--- a/skills-evals/fixtures/conformant-bundle/index.md
+++ b/skills-evals/fixtures/conformant-bundle/index.md
@@ -1,0 +1,8 @@
+---
+okf_version: "0.1"
+---
+
+# E-commerce Analytics Bundle
+
+- [Tables](./tables/) - Database tables powering the analytics stack
+- [Metrics](./metrics/) - Business KPIs derived from tables

--- a/skills-evals/fixtures/conformant-bundle/metrics/gross-revenue.md
+++ b/skills-evals/fixtures/conformant-bundle/metrics/gross-revenue.md
@@ -1,0 +1,25 @@
+---
+type: Metric
+title: Gross Revenue
+description: Total revenue before refunds and discounts.
+tags: [revenue, finance, kpi]
+timestamp: 2026-05-28T14:30:00Z
+---
+
+# Definition
+
+Sum of `total_usd` from [orders](/tables/orders.md) for a given period.
+Does not subtract refunds — see Net Revenue for that.
+
+# SQL
+
+```sql
+SELECT DATE_TRUNC(placed_at, MONTH) as month,
+       SUM(total_usd) as gross_revenue
+FROM `acme.sales.orders`
+GROUP BY 1
+```
+
+# Related
+
+- Source table: [orders](/tables/orders.md)

--- a/skills-evals/fixtures/conformant-bundle/metrics/index.md
+++ b/skills-evals/fixtures/conformant-bundle/metrics/index.md
@@ -1,0 +1,3 @@
+# Metrics
+
+- [Gross Revenue](./gross-revenue.md) - Total revenue before refunds

--- a/skills-evals/fixtures/conformant-bundle/tables/customers.md
+++ b/skills-evals/fixtures/conformant-bundle/tables/customers.md
@@ -1,0 +1,20 @@
+---
+type: BigQuery Table
+title: Customers
+description: One row per registered customer with profile and lifetime data.
+resource: https://console.cloud.google.com/bigquery?p=acme&d=sales&t=customers
+tags: [sales, customers]
+timestamp: 2026-05-28T14:30:00Z
+---
+
+# Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `customer_id` | STRING | Primary key |
+| `email` | STRING | Customer email (hashed in prod) |
+| `created_at` | TIMESTAMP | Registration date |
+
+# Joins
+
+- Referenced by [orders](./orders.md) on `customer_id`

--- a/skills-evals/fixtures/conformant-bundle/tables/index.md
+++ b/skills-evals/fixtures/conformant-bundle/tables/index.md
@@ -1,0 +1,4 @@
+# Tables
+
+- [Orders](./orders.md) - One row per completed customer order
+- [Customers](./customers.md) - One row per registered customer

--- a/skills-evals/fixtures/conformant-bundle/tables/orders.md
+++ b/skills-evals/fixtures/conformant-bundle/tables/orders.md
@@ -1,0 +1,20 @@
+---
+type: BigQuery Table
+title: Orders
+description: One row per completed customer order across all channels.
+resource: https://console.cloud.google.com/bigquery?p=acme&d=sales&t=orders
+tags: [sales, orders, revenue]
+timestamp: 2026-05-28T14:30:00Z
+---
+
+# Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `order_id` | STRING | Globally unique order identifier |
+| `customer_id` | STRING | FK to [customers](./customers.md) |
+| `total_usd` | NUMERIC | Order total in US dollars |
+
+# Joins
+
+- Join with [customers](./customers.md) on `customer_id`

--- a/skills-evals/fixtures/create-output/index.md
+++ b/skills-evals/fixtures/create-output/index.md
@@ -1,0 +1,8 @@
+---
+okf_version: "0.1"
+---
+
+# SaaS Analytics Knowledge Bundle
+
+- [Tables](./tables/) - Core BigQuery tables for users and subscription lifecycle tracking.
+- [Metrics](./metrics/) - Business metrics derived from subscription and user activity.

--- a/skills-evals/fixtures/create-output/metrics/index.md
+++ b/skills-evals/fixtures/create-output/metrics/index.md
@@ -1,0 +1,3 @@
+# Metrics
+
+- [MRR](./mrr.md) - Monthly recurring revenue computed from active subscription records.

--- a/skills-evals/fixtures/create-output/metrics/mrr.md
+++ b/skills-evals/fixtures/create-output/metrics/mrr.md
@@ -1,0 +1,32 @@
+---
+type: Metric
+title: Monthly Recurring Revenue
+description: Sum of normalized monthly revenue from active SaaS subscriptions.
+timestamp: 2026-06-23T00:00:00Z
+tags:
+  - saas
+  - revenue
+  - mrr
+---
+
+# Monthly Recurring Revenue
+
+Monthly Recurring Revenue (MRR) is the sum of `monthly_amount` for active rows in
+[Subscriptions](../tables/subscriptions.md). Analysts often segment MRR by attributes
+from [Users](../tables/users.md), such as plan tier or signup cohort.
+
+## Definition
+
+MRR includes only recurring subscription revenue and excludes one-time fees.
+
+## Formula
+
+`MRR = Σ(monthly_amount for active subscriptions)`
+
+# Examples
+
+```sql
+SELECT SUM(monthly_amount) AS mrr
+FROM `saas_analytics.subscriptions`
+WHERE status = 'active';
+```

--- a/skills-evals/fixtures/create-output/tables/index.md
+++ b/skills-evals/fixtures/create-output/tables/index.md
@@ -1,0 +1,4 @@
+# Tables
+
+- [Users](./users.md) - Dimension table containing account-level user records for the analytics domain.
+- [Subscriptions](./subscriptions.md) - Fact-style table tracking subscription status, plan, and billing periods.

--- a/skills-evals/fixtures/create-output/tables/subscriptions.md
+++ b/skills-evals/fixtures/create-output/tables/subscriptions.md
@@ -1,0 +1,28 @@
+---
+type: BigQuery Table
+title: Subscriptions
+description: Table of subscription contracts, billing intervals, and lifecycle status for each SaaS customer.
+timestamp: 2026-06-23T00:00:00Z
+resource: bigquery://saas_analytics.subscriptions
+tags:
+  - saas
+  - subscriptions
+  - billing
+---
+
+# Subscriptions
+
+The `subscriptions` table tracks each customer's recurring contract, including the
+billing amount and whether the subscription is active. Each record links back to
+[Users](./users.md) through `user_id`, and active rows feed the
+[MRR](../metrics/mrr.md) metric.
+
+# Schema
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `subscription_id` | STRING | Unique identifier for the subscription contract. |
+| `user_id` | STRING | Foreign key to [Users](./users.md). |
+| `monthly_amount` | NUMERIC | Normalized monthly recurring charge for the subscription. |
+| `status` | STRING | Current lifecycle state such as active, paused, or canceled. |
+| `start_date` | DATE | Date the subscription started. |

--- a/skills-evals/fixtures/create-output/tables/users.md
+++ b/skills-evals/fixtures/create-output/tables/users.md
@@ -1,0 +1,26 @@
+---
+type: BigQuery Table
+title: Users
+description: Dimension table containing one row per SaaS user account used for product and revenue analysis.
+timestamp: 2026-06-23T00:00:00Z
+resource: bigquery://saas_analytics.users
+tags:
+  - saas
+  - users
+  - dimensions
+---
+
+# Users
+
+The `users` table stores the canonical user profile for the SaaS analytics domain.
+It is commonly joined to [Subscriptions](./subscriptions.md) on `user_id` to understand
+which accounts contribute to [MRR](../metrics/mrr.md).
+
+# Schema
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `user_id` | STRING | Stable unique identifier for the user account. |
+| `email` | STRING | Primary email address used for communication and login. |
+| `signup_date` | DATE | Date when the user created an account. |
+| `plan_tier` | STRING | Latest known plan tier associated with the user. |

--- a/skills-evals/fixtures/non-conformant/log.md
+++ b/skills-evals/fixtures/non-conformant/log.md
@@ -1,0 +1,7 @@
+# Update Log
+
+## 2026-06-20
+- **Creation**: Added test fixtures.
+
+## June 20, 2026
+- **Bad Date**: This date heading is not ISO 8601.

--- a/skills-evals/fixtures/non-conformant/missing-frontmatter.md
+++ b/skills-evals/fixtures/non-conformant/missing-frontmatter.md
@@ -1,0 +1,4 @@
+# Missing Frontmatter
+
+This file has no YAML frontmatter at all.
+It should trigger an E1 error.

--- a/skills-evals/fixtures/non-conformant/no-type.md
+++ b/skills-evals/fixtures/non-conformant/no-type.md
@@ -1,0 +1,9 @@
+---
+title: Something
+description: This file has frontmatter but no type field.
+tags: [test]
+---
+
+# No Type Field
+
+This should trigger an E2 error.

--- a/skills-evals/fixtures/non-conformant/subdir/index.md
+++ b/skills-evals/fixtures/non-conformant/subdir/index.md
@@ -1,0 +1,7 @@
+---
+unexpected: frontmatter
+---
+
+# Sub Index
+
+- [Item](./item.md) - A concept in the subdirectory

--- a/skills-evals/fixtures/non-conformant/subdir/item.md
+++ b/skills-evals/fixtures/non-conformant/subdir/item.md
@@ -1,0 +1,8 @@
+---
+type: Concept
+---
+
+# Item
+
+Link to [missing](../nonexistent.md) should trigger W2.
+Missing title, description, and timestamp should trigger W1 and W3.

--- a/skills-evals/fixtures/schema-db-yaml/metric.schema.yaml
+++ b/skills-evals/fixtures/schema-db-yaml/metric.schema.yaml
@@ -1,0 +1,46 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: OKF Metric Concept
+description: Schema for a business metric concept in an OKF bundle. Permissive validation — additional properties are allowed.
+type: object
+additionalProperties: true
+properties:
+  type:
+    type: string
+    description: OKF concept type
+    const: metric
+  title:
+    type: string
+    description: Human-readable name of the metric
+  description:
+    type: string
+    description: How the metric is calculated and what it measures
+  timestamp:
+    type: string
+    description: ISO 8601 timestamp of last modification
+    format: date-time
+  formula:
+    type: string
+    description: Mathematical or SQL formula for the metric
+  unit:
+    type: string
+    description: Unit of measurement
+    enum:
+      - count
+      - percentage
+      - currency
+      - ratio
+      - duration
+  refresh_frequency:
+    type: string
+    description: How often the metric is refreshed
+    enum:
+      - real-time
+      - hourly
+      - daily
+      - weekly
+      - monthly
+required:
+  - type
+  - title
+  - description
+  - timestamp

--- a/skills-evals/fixtures/schema-db-yaml/table.schema.yaml
+++ b/skills-evals/fixtures/schema-db-yaml/table.schema.yaml
@@ -1,0 +1,38 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: OKF Table Concept
+description: Schema for a database table concept in an OKF bundle. Strict validation — no additional properties allowed.
+type: object
+additionalProperties: false
+properties:
+  type:
+    type: string
+    description: OKF concept type
+    const: table
+  title:
+    type: string
+    description: Human-readable name of the table
+  description:
+    type: string
+    description: Brief explanation of the table's purpose
+  timestamp:
+    type: string
+    description: ISO 8601 timestamp of last modification
+    format: date-time
+  owner:
+    type: string
+    description: Team or individual responsible for this table
+  tier:
+    type: string
+    description: Data tier classification
+    enum:
+      - bronze
+      - silver
+      - gold
+  pii:
+    type: boolean
+    description: Whether the table contains personally identifiable information
+required:
+  - type
+  - title
+  - description
+  - timestamp

--- a/skills-evals/fixtures/schema-db/metric.schema.json
+++ b/skills-evals/fixtures/schema-db/metric.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OKF Metric Concept",
+  "description": "Schema for a business metric concept in an OKF bundle. Permissive validation — additional properties are allowed.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "OKF concept type",
+      "const": "metric"
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable name of the metric"
+    },
+    "description": {
+      "type": "string",
+      "description": "How the metric is calculated and what it measures"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of last modification",
+      "format": "date-time"
+    },
+    "formula": {
+      "type": "string",
+      "description": "Mathematical or SQL formula for the metric"
+    },
+    "unit": {
+      "type": "string",
+      "description": "Unit of measurement",
+      "enum": ["count", "percentage", "currency", "ratio", "duration"]
+    },
+    "refresh_frequency": {
+      "type": "string",
+      "description": "How often the metric is refreshed",
+      "enum": ["real-time", "hourly", "daily", "weekly", "monthly"]
+    }
+  },
+  "required": ["type", "title", "description", "timestamp"]
+}

--- a/skills-evals/fixtures/schema-db/table.schema.json
+++ b/skills-evals/fixtures/schema-db/table.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OKF Table Concept",
+  "description": "Schema for a database table concept in an OKF bundle. Strict validation — no additional properties allowed.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "OKF concept type",
+      "const": "table"
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable name of the table"
+    },
+    "description": {
+      "type": "string",
+      "description": "Brief explanation of the table's purpose"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of last modification",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "description": "Team or individual responsible for this table"
+    },
+    "tier": {
+      "type": "string",
+      "description": "Data tier classification",
+      "enum": ["bronze", "silver", "gold"]
+    },
+    "pii": {
+      "type": "boolean",
+      "description": "Whether the table contains personally identifiable information"
+    }
+  },
+  "required": ["type", "title", "description", "timestamp"]
+}

--- a/skills-evals/fixtures/schema-invalid-bundle/dashboard.md
+++ b/skills-evals/fixtures/schema-invalid-bundle/dashboard.md
@@ -1,0 +1,10 @@
+---
+type: dashboard
+title: Executive Dashboard
+description: High-level KPI overview.
+timestamp: "2026-01-15T09:00:00Z"
+---
+
+# Executive Dashboard
+
+This concept has type 'dashboard' which has no schema in the schema database.

--- a/skills-evals/fixtures/schema-invalid-bundle/index.md
+++ b/skills-evals/fixtures/schema-invalid-bundle/index.md
@@ -1,0 +1,9 @@
+---
+okf_version: "0.1"
+---
+
+# Schema-Invalid OKF Bundle
+
+- [users](users.md) — invalid table
+- [mrr](mrr.md) — invalid metric
+- [dashboard](dashboard.md) — unknown type

--- a/skills-evals/fixtures/schema-invalid-bundle/mrr.md
+++ b/skills-evals/fixtures/schema-invalid-bundle/mrr.md
@@ -1,0 +1,13 @@
+---
+type: metric
+title: Monthly Recurring Revenue
+description: Sum of all active subscription values.
+timestamp: "2026-01-15T09:00:00Z"
+formula: SUM(value)
+unit: euros
+refresh_frequency: daily
+---
+
+# MRR
+
+This metric uses an invalid unit value ('euros' not in the allowed enum).

--- a/skills-evals/fixtures/schema-invalid-bundle/users.md
+++ b/skills-evals/fixtures/schema-invalid-bundle/users.md
@@ -1,0 +1,14 @@
+---
+type: table
+title: users
+description: Core user accounts table.
+timestamp: "2026-01-15T09:00:00Z"
+owner: data-platform
+tier: gold
+pii: true
+extra_field: not_allowed
+---
+
+# users
+
+This table has an extra field that violates the strict table schema.

--- a/skills-evals/fixtures/schema-valid-bundle/index.md
+++ b/skills-evals/fixtures/schema-valid-bundle/index.md
@@ -1,0 +1,8 @@
+---
+okf_version: "0.1"
+---
+
+# Schema-Validated OKF Bundle
+
+- [users](users.md) — user accounts table
+- [mrr](mrr.md) — monthly recurring revenue metric

--- a/skills-evals/fixtures/schema-valid-bundle/mrr.md
+++ b/skills-evals/fixtures/schema-valid-bundle/mrr.md
@@ -1,0 +1,21 @@
+---
+type: metric
+title: Monthly Recurring Revenue
+description: Sum of all active subscription values normalized to a 30-day month.
+timestamp: "2026-01-15T09:00:00Z"
+formula: SUM(subscription_value * days_in_month / billing_cycle_days)
+unit: currency
+refresh_frequency: daily
+---
+
+# Monthly Recurring Revenue (MRR)
+
+MRR is the primary revenue metric for the SaaS analytics dashboard.
+
+## Definition
+
+Sum of all active subscription values, normalized to a 30-day month.
+
+## Related Concepts
+
+- [users](users.md) — user accounts that generate subscriptions

--- a/skills-evals/fixtures/schema-valid-bundle/users.md
+++ b/skills-evals/fixtures/schema-valid-bundle/users.md
@@ -1,0 +1,25 @@
+---
+type: table
+title: users
+description: Core user accounts table containing registration and profile data.
+timestamp: "2026-01-15T09:00:00Z"
+owner: data-platform
+tier: gold
+pii: true
+---
+
+# users
+
+The `users` table is the central identity store for the SaaS platform.
+
+## Columns
+
+| Column      | Type      | Description                |
+|-------------|-----------|----------------------------|
+| user_id     | UUID      | Primary key                |
+| email       | VARCHAR   | Unique user email          |
+| created_at  | TIMESTAMP | Account creation time      |
+
+## Related Concepts
+
+- [mrr](mrr.md) — revenue tied to active users


### PR DESCRIPTION
Adds a complete skill evaluation system under skills-evals/ that validates okf-schema against conformant and non-conformant fixture bundles. Includes JSONSchema and YAML schema database support, A/B comparison across iterations, and an interactive HTML dashboard.

New just commands:
- just copilot-cli-eval-okf-schema
- just eval-okf-schema
- just eval-view-okf-schema
 
