### PR TITLE
fix(okf): accept root concepts and bundle attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - add ofkreq and requirements traceability
 
+### Fix
+
+- **okf**: accept root concepts and bundle attachments
+
 ## v0.10.0 (2026-08-10)
 
 ### Feat

--- a/docs/source/how-to/validate-standalone-files.md
+++ b/docs/source/how-to/validate-standalone-files.md
@@ -182,7 +182,7 @@ The `validate-md` command checks the following (unless noted as bundle-only):
 
 - W2: Broken cross-links (no common bundle root)
 - W4: Missing `index.md` in directories
-- E3, E6, E7: Bundle structure rules
+- E3, E6: Bundle structure rules
 
 For full reference, see [Validation Error & Warning Codes](../reference/validation-codes).
 

--- a/docs/source/reference/okf-schema-vs-spec.md
+++ b/docs/source/reference/okf-schema-vs-spec.md
@@ -40,7 +40,7 @@ The spec also permits any additional frontmatter keys beyond the standard fields
 This makes `okf-schema` bundles self-describing and machine-enforceable. The
 trade-off is that you must maintain a schema for every concept type you use.
 
-## 2. No root concepts
+## 2. Root concepts and attachments
 
 ### What the spec says
 
@@ -57,23 +57,21 @@ my_bundle/
 
 ### What OKF-Schema does
 
-`okf-schema` enforces **E7**: non-reserved `.md` files at the bundle root are
-errors. The only files allowed at the root are:
-
-* `index.md` — directory listing
-* `log.md` — update history
-
-All concepts must live inside subdirectories:
+`okf-schema` follows the specification: concept documents may live at the root
+or in nested subdirectories. Non-Markdown files are ignored by document
+validation, so images and other attachments may live alongside the concepts
+that reference them:
 
 ```
 my_bundle/
 ├── index.md
-├── log.md
-└── tables/
-    └── orders.md        # ← correct placement
+├── overview.md
+└── assets/
+    └── architecture.png
 ```
 
-This rule encourages a namespaced structure from the start and prevents
+In `overview.md`, a standard relative Markdown reference such as
+`![Architecture](assets/architecture.png)` is validated as an internal link.
 
 ## See also
 
@@ -81,8 +79,6 @@ This rule encourages a namespaced structure from the start and prevents
 - [Why an Opinionated Knowledge Base?](../explanation/okfkb-choices) — how opinionation works in practice.
 - [Write a Custom Schema](../how-to/write-custom-schema) — authoring schemas that enforce these constraints.
 - [Getting Started](../tutorials/getting-started) — tutorial covering bundle creation and validation.
-root-level clutter as the bundle grows.
-
 ## 3. Additional properties are schema-controlled
 
 ### What the spec says
@@ -135,7 +131,8 @@ specific reason to anchor to the bundle root.
 | `type` field | Required, any string | Must match a schema file in `_schema/` |
 | Frontmatter fields | Any keys allowed | Validated against JSONSchema |
 | Extra / unknown keys | Always tolerated | Controlled by `additionalProperties` |
-| Root `.md` files | Allowed | Forbidden (E7); only `index.md` and `log.md` |
+| Root `.md` files | Allowed | Allowed |
+| Non-Markdown attachments | Allowed as referenced resources | Allowed and ignored by document validation |
 | Internal link style | Relative or bundle-relative | Both supported; **relative preferred** |
 | Link metadata | Implicit (only in body) | Explicit `links` / `backlinks` frontmatter |
 | Schema location | None (spec does not use schemas) | `_schema/*.schema.{yaml,json,json5}` |

--- a/docs/source/reference/validation-codes.md
+++ b/docs/source/reference/validation-codes.md
@@ -146,20 +146,20 @@ Move the file to the correct location. For `log.md`, it must be at the root of y
 
 ---
 
-### E7: Non-Reserved File at Bundle Root
+### E7: Retired
 
-**Severity**: Error (OKF bundle validation only)
+`E7` formerly rejected non-reserved Markdown files at the bundle root. It is no
+longer emitted: OKF 0.2 explicitly permits concept documents both at the root
+and in subdirectories.
 
-**Description**: A non-reserved markdown file (not `index.md` or `log.md`) exists at the bundle root. All concept files must be in subdirectories.
-
-**How to Fix**:
-Move the markdown file into a subdirectory (e.g., `concepts/`, `principles/`, etc.):
+For example, this structure is valid:
 ```
 bundle/
-  concepts/
-    my-concept.md      # Correct location
   index.md
   log.md
+  overview.md
+  concepts/
+    details.md
 ```
 
 ---
@@ -620,9 +620,13 @@ Use `--strict` in CI/CD pipelines to enforce best practices.
 
 When validating an OKF bundle, the following checks are applied:
 
-**All files**: E1, E2, E4, E5, E8-E10, W1, W2, W3, W6-W13
+**All Markdown files**: E1, E2, E4, E5, E8-E10, W1, W2, W3, W6-W13
 **Reserved files**: E3, E6
-**Bundle structure**: E7, W4
+**Bundle structure**: W4
+
+Non-Markdown files are not concept documents and are ignored by document
+validation. They may be stored in the bundle and referenced as attachments from
+Markdown concepts.
 
 ### Standalone Validation (`validate-md`)
 
@@ -633,7 +637,7 @@ When validating standalone markdown files without a bundle, the following checks
 **Not applied** (bundle-specific):
 - W2 (broken links require a common root for resolution)
 - W4 (directory structure validation)
-- E3, E6, E7 (bundle structure rules)
+- E3, E6 (bundle structure rules)
 
 ---
 

--- a/requirements/tiers/swrs/core/SwRS-OKFSCHEMA-CORE-001.md
+++ b/requirements/tiers/swrs/core/SwRS-OKFSCHEMA-CORE-001.md
@@ -46,6 +46,14 @@ report actionable results without silently changing authored content.
 - WHEN the user runs the validation command
 - THEN the command identifies the invalid document and exits unsuccessfully
 
+### Scenario: Accept portable bundle contents
+
+- GIVEN an OKF bundle containing conforming concept documents at its root or in
+  subdirectories and non-Markdown files referenced as attachments
+- WHEN the user runs the validation command
+- THEN the concept documents are validated at either location and the
+  non-Markdown attachments do not produce document validation errors
+
 ### Verification notes
 
 - Method: automated CLI and API tests using valid and invalid bundle fixtures.

--- a/skills/okf-schema/SKILL.md
+++ b/skills/okf-schema/SKILL.md
@@ -199,7 +199,7 @@ for c in concepts:
 | E4 | Schema validation | Frontmatter must validate against its type's JSONSchema |
 | E5 | Flat lists | Frontmatter lists must not be nested (e.g. `tags: [[a], b]`) |
 | E6 | Reserved file location | `log.md` must exist only at bundle root |
-| E7 | Loose root file | Non-reserved `.md` files must not be placed at bundle root; move them into subdirectories |
+| E7 | Retired | Root-level concept documents are allowed by OKF 0.2 |
 | E8 | Generated provenance | `generated` is not a mapping with a valid `at` value |
 | E9 | Source metadata | A source lacks `resource` or duplicates another source ID |
 | E10 | Trust/lifecycle metadata | Verification or lifecycle date structure is invalid |
@@ -276,7 +276,7 @@ my-bundle/
 
 Validation: 2 errors, 1 warning
 - E2: metrics/mrr.md — missing 'type' field
-- E7: root-concept.md — non-reserved file at bundle root
+- W2: metrics/churn.md — broken link to a missing attachment
 - W4: metrics/ — directory missing index.md
 ```
 

--- a/src/okf_schema/validator.py
+++ b/src/okf_schema/validator.py
@@ -721,9 +721,10 @@ def validate_bundle(
     """Run the full validation suite over *bundle*.
 
     Orchestrates all validators and emits W4 (missing index.md) for
-    directories that contain markdown files but no ``index.md``,
-    and E7 (loose root file) for non-reserved ``.md`` files at bundle
-    root.
+    directories that contain markdown files but no ``index.md``. Concept
+    documents may appear at the bundle root or in subdirectories, as allowed
+    by OKF 0.2. Non-markdown files are ignored by document validation and may
+    be kept in the bundle as attachments or other referenced resources.
 
     Args:
         bundle: Path to the OKF bundle directory.
@@ -754,14 +755,6 @@ def validate_bundle(
             _check_reserved_file_naming(path, report, bundle)
         else:
             validate_concept(path, report, bundle, schemas)
-            # E7 — non-reserved .md files at bundle root
-            if path.parent.resolve() == bundle.resolve():
-                report.add_error(
-                    "E7",
-                    f"File '{path.name}' is at bundle root but is not a reserved file "
-                    "(index.md or log.md). Move it into a subdirectory.",
-                    path,
-                )
 
     # W4 — directories missing index.md
     for directory in dirs_with_md:
@@ -786,7 +779,7 @@ def validate_markdown_files(
 
     Validates each file using E1, E2, E4, E5, E8-E10 and W1, W3,
     W6-W13 rules.
-    Bundle-specific constraints (E7, W4, E6, W5) are not applied.
+    Bundle-specific constraints (W4, E6, W5) are not applied.
     Links are not validated since there is no common root.
 
     Args:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -86,7 +86,7 @@ class TestEndToEndWorkflow:
         assert result.exit_code == 0
         bundle = project / "bundle"
 
-        # Add concepts via CLI new (in subdirectories to comply with E7)
+        # Add concepts via CLI new
         runner.invoke(
             cli,
             ["new", "--path", str(bundle), "--name", "concepts/alpha", "--type", "concept"],

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -742,18 +742,6 @@ class TestValidateBundleE6:
         assert any(f.code == "E6" for f in report.errors)
 
 
-class TestValidateBundleE7:
-    """E7 tests using fixtures."""
-
-    def test_e7_loose_root_file(self) -> None:
-        """E7 triggered when a non-reserved .md file is at bundle root."""
-        bundle = BUNDLE_FIXTURES / "invalid" / "e7-loose-root-file"
-        report = validate_bundle(bundle)
-        assert any(f.code == "E7" for f in report.errors)
-        e7 = next(f for f in report.errors if f.code == "E7")
-        assert "loose-concept.md" in e7.message
-
-
 class TestValidateBundleW1:
     """W1 tests using fixtures."""
 
@@ -909,52 +897,39 @@ class TestValidateBundleEdgeCases:
         report = validate_bundle(tmp_path, None)
         assert report.is_conformant is True
 
-    def test_e7_root_concept_triggers_error(self, tmp_path: Path) -> None:
-        """E7 triggered when a concept .md is placed at bundle root."""
-        path = tmp_path / "concept.md"
-        path.write_text(
-            "---\n"
-            "title: Test\n"
-            "description: A test\n"
-            "type: concept\n"
-            "timestamp: 2024-01-01\n"
-            "---\n\n"
-            "# Test\n"
-        )
-        report = validate_bundle(tmp_path)
-        assert not report.is_conformant
-        assert any(f.code == "E7" for f in report.errors)
-        e7 = next(f for f in report.errors if f.code == "E7")
-        assert "concept.md" in e7.message
 
-    def test_e7_multiple_root_files(self, tmp_path: Path) -> None:
-        """E7 triggered for each non-reserved .md at bundle root."""
-        (tmp_path / "a.md").write_text("---\ntitle: A\ntype: concept\n---\n\n# A\n")
-        (tmp_path / "b.md").write_text("---\ntitle: B\ntype: concept\n---\n\n# B\n")
-        report = validate_bundle(tmp_path)
-        e7s = [f for f in report.errors if f.code == "E7"]
-        assert len(e7s) == 2
+def test_root_concept_is_allowed(tmp_path: Path) -> None:
+    """A conforming concept may be placed at the bundle root."""
+    path = tmp_path / "concept.md"
+    path.write_text(
+        "---\n"
+        "title: Test\n"
+        "description: A test\n"
+        "type: concept\n"
+        "timestamp: 2024-01-01\n"
+        "---\n\n"
+        "# Test\n"
+    )
+    report = validate_bundle(tmp_path)
+    assert report.is_conformant
+    assert report.errors == []
 
-    def test_no_e7_for_reserved_root_files(self, tmp_path: Path) -> None:
-        """index.md and log.md at root do not trigger E7."""
-        (tmp_path / "index.md").write_text("---\nokf_version: '0.1'\n---\n\n# Index\n")
-        (tmp_path / "log.md").write_text("# Log\n\n## 2024-01-15\n\n- Entry\n")
-        report = validate_bundle(tmp_path)
-        assert not any(f.code == "E7" for f in report.errors)
 
-    def test_no_e7_for_subdir_concepts(self, tmp_path: Path) -> None:
-        """Concepts in subdirectories do not trigger E7."""
-        subdir = tmp_path / "concepts"
-        subdir.mkdir()
-        path = subdir / "concept.md"
-        path.write_text(
-            "---\n"
-            "title: Test\n"
-            "description: A test\n"
-            "type: concept\n"
-            "timestamp: 2024-01-01\n"
-            "---\n\n"
-            "# Test\n"
-        )
-        report = validate_bundle(tmp_path)
-        assert not any(f.code == "E7" for f in report.errors)
+def test_non_markdown_attachment_is_allowed(tmp_path: Path) -> None:
+    """Non-markdown files may be attached to a concept without validation errors."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "diagram.png").write_bytes(b"not-a-real-png")
+    (tmp_path / "concept.md").write_text(
+        "---\n"
+        "title: Test\n"
+        "description: A test with an image\n"
+        "type: concept\n"
+        "timestamp: 2024-01-01\n"
+        "---\n\n"
+        "![Diagram](assets/diagram.png)\n"
+    )
+    report = validate_bundle(tmp_path)
+    assert report.is_conformant
+    assert report.errors == []
+    assert not any(f.code in {"W2", "W4"} for f in report.warnings)


### PR DESCRIPTION
OKF 0.2 bundles can keep conforming concepts
at the bundle root and reference non-Markdown assets
such as images without structural validation errors.

Documentation now distinguishes concept validation
from attachment handling and marks the former E7
restriction as retired.